### PR TITLE
simplify waitTime by removing amap

### DIFF
--- a/src/waitTimes.ts
+++ b/src/waitTimes.ts
@@ -14,3 +14,19 @@ export function minimumWaitingTime(queries: number[]) {
     }), 0);
 
 };
+
+export function simple_minimumWaitingTime(queries: number[]) {
+  // Write your code here.
+	
+	let curWait = 0;
+	
+	return queries.sort((a, b) => a-b).reduce((totalWait, cur) => {
+		
+		let indexWait = totalWait + curWait;
+		
+		curWait += cur;
+		
+		return indexWait;
+	}, 0);
+	
+}


### PR DESCRIPTION
seems impossible to improve upon O(logn), ie. no sorting

optimal wait time lines have quick reqs pushed to the front of the line. this way every waitIndex incurs the sum of all waitIndices lesser than it. 

ie. to determine the waitTime for any particular index, I either 
[0] need information from all other indices. (so that's O(n) * O(n)). 
[1] need nested loop that 'jumps off' a particular index per outer iteration to summate with nums lesser than it

sort solves this cleanly by allowing me to assume that everything before the particular index I'm at can be summed up to a wait time for this problem