### PR TITLE
implements threeNumSort with 4 loops

### DIFF
--- a/src/threeNumSort.ts
+++ b/src/threeNumSort.ts
@@ -1,0 +1,48 @@
+export function threeNumberSort(array: number[], order: number[]) {
+// Write your code here.
+    
+    let x = order[0];
+    let y = order[1];
+    let z = order[2];
+    
+    let xCount = 0;
+    let yCount = 0;
+    let zCount = 0;
+    
+    for (let i = 0; i < array.length; i++) {
+        
+        switch(array[i]) {
+                
+            case x:
+                xCount++;
+                break;
+                
+            case y:
+                yCount++;
+                break;
+                
+            case z:
+                zCount++;
+                break;
+                
+            default:
+                break;
+                
+        }
+        
+    }
+    
+    for (let i = 0; i < xCount; i++) {
+        array[i] = x;
+    }
+    
+    for (let i = array.length-1; i > array.length-1-zCount; i--) {
+        array[i] = z;
+    }
+    
+    for (let i = xCount; i < xCount + yCount; i++) {
+        array[i] = y;
+    }
+    
+return array;
+}


### PR DESCRIPTION
Problem: Given an input of 2 arrays, determine a 'sorted' version of the longer array. The other array will have 3 indexes, with 3 distinct characters. Only those 3 characters will be found within the long array and the sort should order  them in the same order as indicated in the 3 index array. 

Solution: We can represent the sort order as [x, y, z]

So I solve this with 4 loops that first counts the number of each occurrence and then injects in the characters in the range where they should sit based on how many there are and their relative order. 
First loop -> count the number of occurrences of each of the 3 letters
Second loop -> looping from 0 to x(excluding x), replace array at i with x
Third loop -> looping from x to x+y(excluding x+y), repalace array at i with y
Fourth loop -> looping from array.length-1 to array.length-1-z(excluding z), replace array at i with z(I guess prob loop this forwards works too. might read easier)