### PR TITLE
finds longest substring witout dupe by tracking nondupe string ranges…

### DIFF
--- a/src/longestSubstringWithoutDupe.ts
+++ b/src/longestSubstringWithoutDupe.ts
@@ -1,0 +1,26 @@
+export function longestSubstringWithoutDuplication(string: string) {
+
+// Write your code here.
+    let runningCache: { [key: string]: number } = {};
+// 	stored as ranges so as to not incur a nested O(n) from slicing strings
+// 	upper bound is inclusive here!
+    let curString = [0, 0];
+
+    let runningString = [0, 0];
+    
+    for (let i = 0; i < string.length; i++) {
+// [] - if curChar is part of the current string's range, ie dupe found within curRange
+        if (string[i] in runningCache && runningCache[string[i]] >= curString[0]) {
+// [] - start the next range 1 index after most recent dupe
+            curString[0] = runningCache[string[i]]+1;
+
+        } 
+// [] - update curString's endBound, add or update character's most recent index in runningCache
+        curString[1] = i;
+        runningCache[string[i]] = i;
+// [] - check if curString is longer than runningString, replace if so
+        if (i-curString[0] > runningString[1]-runningString[0]) [runningString[0], runningString[1]] = [curString[0], i];
+    }
+    
+    return string.slice(runningString[0], runningString[1]+1);
+}


### PR DESCRIPTION
… within cache

Problem: find the longest substring within the string that doesn't have duplicate characters (assuming only 1)

Solution: When a duplicate is found, the next substring needs to start at index of previousDupe+1, not i. In other words, non-dupe substrings can have overlapping cases. So therefore, the cache also needs to reflect that range. Instead of resetting the cache, I cache and recache everything. I check whether the duplicate found is within the window of my currently tracked substring. Whenever I run into values, I simply overwrite with the mostRecentIndex. 

This way, I'm asking the question: did I find a duplicate? And is that duplicate within the window of my current substring? 

cache model: { [key: character]: mostRecentIndex }

So in this manner I'm able to track & validate non-dupe substrings and track the longest of them, overwriting as I find longer ones. 