### PR TITLE
rebuilds stringweaving to iterate where possible

### DIFF
--- a/src/interweavingString.ts
+++ b/src/interweavingString.ts
@@ -1,54 +1,74 @@
 export function interweavingStrings(one: string, two: string, three: string) {
-// Write your code here.
-    if ((one+two).length !== three.length) return false;
-    
-    return re_weaveStrings(one, two, three, 0, 0, 0, '');
+  // Write your code here.
+	if ((one+two).length !== three.length) return false;
+	
+	const visited = new Set<string>();
+	const canHasInterweave = re_weaveStrings(one, two, three, 0, 0, 0, '', visited);
+
+	return canHasInterweave;
 
 }
 
 function re_weaveStrings(
-        one: string,
-        two: string,
-        three: string,
-        o: number,
-        t: number,
-        th: number,
-        curString: string,
-        visited: Set<string> = new Set<string>()
+		one: string,
+		two: string,
+		three: string,
+		o: number,
+		t: number,
+		th: number,
+		curString: string,
+		visited: Set<string>
 ) {
-
-// base cases: 
+// edge case: if current path permutation has been arrived at before from a diff route, everything forward has also already been traversed
     if (visited.has( (o+'')+(t+'') )) return false;
     visited.add( (o+'')+(t+'') );
-
-    // [0] - string has naturally reached it's end
-    if (th >= three.length) {
-        if (curString === three) return true;
-        else return false;
-    }
-    // [1] - first string used up
-    if (o >= one.length) {
-        if (curString + two.slice(t, two.length) === three) return true;
-        else return false;
-    }
-    // [2] - second string used up
-    if (t >= two.length) {
-        if (curString + one.slice(o, one.length) === three) return true;
-        else return false;
-    }
-    // [3] - match not found
-    if (one[o] !== three[th] && two[t] !== three[th]) {
-        return false;
-    }
-    // [4] - weave cases
-    // [a] - the 'end' character from string one matches end character in string three
-    if (one[o] === three[th]) {
-        if (re_weaveStrings(one, two, three, o+1, t, th+1, curString+one[o])) return true;
-    }
-    // [b] - the 'end' character from string two matches end character in string three
-    if (two[t] === three[th]) {
-        if (re_weaveStrings(one, two, three, o, t+1, th+1, curString+two[t])) return true;
-    }
+    // implementation: iterate the parts I can iterate, recurse when match found on both ends
     
-    return false;
+    let runningString = curString;
+    
+    let oP = o;
+    let tP = t;
+    
+    for (let i = th; i < three.length; i++) {
+        // [] - neither ends match
+        if (one[oP] !== three[i] && two[tP] !== three[i]) return false;
+        
+        // [0] - string has naturally reached it's end
+        if (i >= three.length) {
+            if (runningString === three) return true;
+            else return false;
+        }
+        // [1] - first string used up
+        if (oP >= one.length) {
+            if (runningString + two.slice(tP, two.length) === three) return true;
+            else return false;
+        }
+        // [2] - second string used up
+        if (tP >= two.length) {
+            if (runningString + one.slice(oP, one.length) === three) return true;
+            else return false;
+        }
+        
+        // [] - weave cases
+        if (one[oP] === three[i] && two[tP] === three[i]) {
+            if (re_weaveStrings(one, two, three, oP+1, tP, i+1, runningString+one[oP], visited)) return true;
+            if (re_weaveStrings(one, two, three, oP, tP+1, i+1, runningString+two[tP], visited)) return true;
+            return false;
+        }
+        // [] - one end match cases: 
+        if (one[oP] === three[i]) {
+            runningString += one[oP];
+            oP++;
+        }
+        
+        if (two[tP] === three[i]) {
+            runningString += two[tP];
+            tP++;
+        }
+        
+        visited.add( (oP+'')+(tP+'') );
+        
+    }
+
+    
 }


### PR DESCRIPTION
Fix: string progressions only require recursion when both ends match, the rest is now being performed iteratively where possible to not overwhelm the call stack